### PR TITLE
Rerender current frame on live reload

### DIFF
--- a/renin/src/renin.ts
+++ b/renin/src/renin.ts
@@ -394,6 +394,9 @@ export class Renin {
       this.root = updated;
     }
     newNode.resize(this.screenRenderTarget.width, this.screenRenderTarget.height);
+
+    /* To rerender the current frame */
+    setTimeout(() => this.jumpToFrame(this.frame), 0);
   }
 
   loop = () => {


### PR DESCRIPTION
<h4>Rerender current frame on live reload</h4>


This makes it easier to develop an effect while paused. Contrary to nin,
renin doesn't continuously rerender while paused. Therefore, we must
explicitly rerender on live reload instead.

