### PR TITLE
Bump to version 2.0.0

### DIFF
--- a/renin/package.json
+++ b/renin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renin",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "bin": "cli",
   "module": "lib/renin.js",
   "files": [

--- a/renin/src/ReninNode.ts
+++ b/renin/src/ReninNode.ts
@@ -15,6 +15,7 @@ export class ReninNode {
 
   /* The unique node id of this node. */
   id: string;
+  renin: Renin;
 
   /* Subclasses can implement this if they need code to happen in the
    * update stage. Update is guaranteed to be called exactly 60 times
@@ -33,8 +34,9 @@ export class ReninNode {
   // @ts-ignore
   resize(width: number, height: number): void {}
 
-  constructor() {
+  constructor(renin: Renin) {
     this.id = this.constructor.name + '-' + ((1000000 * Math.random()) | 0);
+    this.renin = renin;
     console.log('new', this.id);
   }
 

--- a/renin/src/renin.ts
+++ b/renin/src/renin.ts
@@ -43,7 +43,7 @@ export interface Options {
     subdivision: number;
     beatOffset: number;
   };
-  root: ReninNode;
+  root: typeof ReninNode;
   productionMode: boolean;
   rendererOptions?: WebGLRendererParameters;
   toneMapping: WebGLRenderer['toneMapping'];
@@ -129,9 +129,9 @@ export class Renin {
   constructor(options: Options) {
     Renin.instance = this;
     this.options = options;
-    this.root = options.root;
     this.renderer = new WebGLRenderer(options.rendererOptions);
     this.renderer.physicallyCorrectLights = true;
+    this.root = new options.root(this);
     this.audioBar = new AudioBar(this);
 
     const body = document.getElementsByTagName('body')[0];
@@ -373,7 +373,8 @@ export class Renin {
   }
 
   /* for hmr */
-  register(newNode: ReninNode) {
+  register(newNodeClass: typeof ReninNode) {
+    const newNode = new newNodeClass(this);
     function recurse(node: ReninNode): ReninNode | null {
       if ('children' in node && node.children) {
         for (const [id, child] of Object.entries(node.children)) {

--- a/renin/src/ui/screenShader.glsl
+++ b/renin/src/ui/screenShader.glsl
@@ -4,7 +4,7 @@ uniform sampler2D thirdsOverlay;
 uniform float thirdsOverlayOpacity;
 
 void main() {
-    vec3 color = texture2D(screen, vUv.xy).rgb;
+    vec3 color = LinearTosRGB(texture2D(screen, vUv.xy)).rgb;
     float a = texture2D(thirdsOverlay, vUv.xy).a;
     vec3 inverted = 1. - color;
     color = mix(color, inverted, a * thirdsOverlayOpacity);

--- a/renin/src/ui/vite.ts
+++ b/renin/src/ui/vite.ts
@@ -10,7 +10,7 @@ export default function reninPlugin() {
           src += `
 if (import.meta.hot) {
   import.meta.hot.accept((module) => {
-    Renin.instance.register(new module.${match[1]}());
+    Renin.instance.register(module.${match[1]});
   });
 }
         `;

--- a/renin/src/utils.ts
+++ b/renin/src/utils.ts
@@ -12,7 +12,7 @@ export function children<T>(spec: any): T {
       if (store[prop]) {
         return store[prop];
       } else {
-        store[prop] = new spec[prop]();
+        store[prop] = spec[prop];
         return store[prop];
       }
     },


### PR DESCRIPTION
<h4>Pass renin instance to node constructor</h4>


This way, we can do things with renin.renderer in the constructor of
nodes, if needed. This is a breaking change, since nodes will now need
to new up their children instead of just enumerating their classes.


<hr />


<h4>Rework sRGB/Linear color workflow</h4>


Maybe this is better? The idea is that textures are typically
interpreted as sRGB on load, then all operations and renders are linear,
then finally the very last rendering to the screen converts to sRGB
again.

In order to not completely crush colors, I found this only works well
with float rendertargets. Maybe that is a symptom of things not being
implemented properly? Or maybe that's just expected behavior? This is
probably not the last time we tweak color management in renin.

See https://threejs.org/docs/#manual/en/introduction/Color-management
for more information about color management in Three.js.


<hr />


<h4>Bump to version 2.0.0</h4>



