### PR TITLE
Remember mute state across reloads

### DIFF
--- a/renin/src/renin.ts
+++ b/renin/src/renin.ts
@@ -29,6 +29,7 @@ import performancePanelShader from './ui/performancePanel.glsl';
 import { thirdsOverlayTexture } from './ui/thirdsOverlay';
 import { performancePanelTexture } from './ui/performancePanelTexture';
 import { ColorManagement } from 'three/src/math/ColorManagement';
+import { getSetting, setSetting } from './ui/storedSettings';
 
 /* otherwise it won't be added to the build */
 export * as vite from './ui/vite';
@@ -200,6 +201,8 @@ export class Renin {
 
     this.scene.add(this.audioBar.obj);
 
+    this.music.setVolume(getSetting('volume'));
+
     (async () => {
       const response = await fetch(options.music.src);
       const data = await response.arrayBuffer();
@@ -226,7 +229,9 @@ export class Renin {
       const backskipSlop = this.music.paused ? 0 : 20;
       console.log(e.key);
       if (e.key === 'm') {
-        this.music.setVolume(this.music.getVolume() === 1 ? 0 : 1);
+        const newVolume = this.music.getVolume() === 1 ? 0 : 1;
+        setSetting('volume', newVolume);
+        this.music.setVolume(newVolume);
       }
       if (e.key === 'o') {
         this.screen.getMaterial().uniforms.thirdsOverlayOpacity.value =

--- a/renin/src/ui/storedSettings.ts
+++ b/renin/src/ui/storedSettings.ts
@@ -1,0 +1,21 @@
+const defaultSettings = {
+  volume: 1,
+};
+
+type SettingKey = keyof typeof defaultSettings;
+
+function computeKey(key: SettingKey): string {
+  return `renin-${key}`;
+}
+
+export function getSetting<T extends SettingKey>(key: T): typeof defaultSettings[T] {
+  const raw = localStorage[computeKey(key)];
+  if (raw !== undefined) {
+    return JSON.parse(raw);
+  }
+  return defaultSettings[key];
+}
+
+export function setSetting<T extends SettingKey>(key: T, value: typeof defaultSettings[T]) {
+  localStorage[computeKey(key)] = JSON.stringify(value);
+}


### PR DESCRIPTION
This adds a bare-bones settings-helper on top of localstorage to make it
easy to read and write values that should be persisted, in a way that
does not get in the way of other things running on localhost:3000

This fixes #48.