### PR TITLE
Repair colors for texture-based UI parts

### DIFF
--- a/renin/src/renin.ts
+++ b/renin/src/renin.ts
@@ -198,6 +198,7 @@ export class Renin {
     this.framePanelCanvas = document.createElement('canvas');
     this.framePanelTexture = new CanvasTexture(this.framePanelCanvas);
     this.framePanel.setTexture(this.framePanelTexture, true);
+    this.framePanelTexture.encoding = sRGBEncoding;
 
     this.scene.add(this.audioBar.obj);
 

--- a/renin/src/ui/AudioBar.ts
+++ b/renin/src/ui/AudioBar.ts
@@ -8,6 +8,7 @@ import {
   RepeatWrapping,
   ShaderMaterial,
   BoxBufferGeometry,
+  sRGBEncoding,
 } from 'three';
 import { colors } from './colors';
 import { Music } from '../music';
@@ -59,6 +60,7 @@ const getNodeTexture = (name: string) => {
     ctx.fillText(name, 16, boxHeight / 2);
     const texture = new CanvasTexture(canvas);
     store[name] = texture;
+    texture.encoding = sRGBEncoding;
     return texture;
   }
 };

--- a/renin/src/ui/performancePanelTexture.ts
+++ b/renin/src/ui/performancePanelTexture.ts
@@ -1,4 +1,4 @@
-import { CanvasTexture } from 'three';
+import { CanvasTexture, sRGBEncoding } from 'three';
 import { colors } from './colors';
 import { bootstrapCss } from './css';
 bootstrapCss();
@@ -33,3 +33,4 @@ if (ctx) {
 }
 
 export const performancePanelTexture = new CanvasTexture(canvas);
+performancePanelTexture.encoding = sRGBEncoding;

--- a/renin/src/ui/thirdsOverlay.ts
+++ b/renin/src/ui/thirdsOverlay.ts
@@ -1,4 +1,4 @@
-import { CanvasTexture } from 'three';
+import { CanvasTexture, sRGBEncoding } from 'three';
 import { bootstrapCss } from './css';
 bootstrapCss();
 
@@ -83,3 +83,4 @@ if (thirdsOverlayCtx) {
 }
 export const thirdsOverlayTexture = new CanvasTexture(thirdsOverlayCanvas);
 thirdsOverlayTexture.needsUpdate = true;
+thirdsOverlayTexture.encoding = sRGBEncoding;


### PR DESCRIPTION
<h4>Repair colors for texture-based UI parts</h4>


The colors in the UI were warped in the previous change to the color
management pipeline. This restores the original colors so that they work
with the new color management pipeline.

