### PR TITLE
Add configurable max size for demo

### DIFF
--- a/renin/src/renin.ts
+++ b/renin/src/renin.ts
@@ -52,6 +52,8 @@ export interface Options {
   productionMode: boolean;
   rendererOptions?: WebGLRendererParameters;
   toneMapping: WebGLRenderer['toneMapping'];
+  maxWidth: number;
+  maxHeight: number;
 }
 
 export class Renin {
@@ -379,10 +381,10 @@ export class Renin {
     this.camera.updateProjectionMatrix();
     this.audioBar.resize(width, height);
 
-    let demoWidth = width;
+    let demoWidth = Math.min(width, this.options.maxWidth);
     let demoHeight = (demoWidth / 16) * 9;
     if (demoHeight > height) {
-      demoHeight = height;
+      demoHeight = Math.min(height, this.options.maxHeight);
       demoWidth = (demoHeight / 9) * 16;
     }
     if (!this.isFullscreen) {


### PR DESCRIPTION
<h4>Add configurable max size for demo</h4>


Useful if you want to e.g. constrain demo size to 720p, for performance
reasons. Also useful for working in max 720p or smaller in fullscreen
mode during development on laptops.

