### PR TITLE
Downgrade rollup to 2.x again

### DIFF
--- a/renin/package.json
+++ b/renin/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^18.11.0",
     "@types/three": "^0.144.0",
     "prettier": "^2.7.1",
-    "rollup": "^3.2.0",
+    "rollup": "^2.70.2",
     "rollup-plugin-import-css": "^3.0.3",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-string": "^3.0.0",

--- a/renin/yarn.lock
+++ b/renin/yarn.lock
@@ -523,10 +523,10 @@ rollup-pluginutils@^2.4.1, rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.2.0.tgz#a6f44074418e55217967c8eca622f9638d396388"
-  integrity sha512-0ZkFPyBNvx717KvC700NoxUD31aEEX675u6INJVAmBgKtQuCL8jmmJCj1b9B/qDSnILAvASVKa7UpGS+FLN6AQ==
+rollup@^2.70.2:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
This fixes an issue from f0ccb84ba4ed76013b2cbf1025dd67e9cd46c3f7, since it seems Vite.js is not yet compatible with rollup 3.x

I just kept getting the error:
> TypeError: Unknown file extension ".ts" for ~/Projects/renin/renin/rollup.config.ts