### PR TITLE
Set fullscreen when running in production mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+.idea

--- a/renin/src/renin.ts
+++ b/renin/src/renin.ts
@@ -142,6 +142,7 @@ export class Renin {
     //@ts-ignore
     ColorManagement.legacyMode = false;
     this.options = options;
+    this.isFullscreen = this.options.productionMode;
     this.renderer = new WebGLRenderer(options.rendererOptions);
     this.renderer.physicallyCorrectLights = true;
     this.renderer.outputEncoding = LinearEncoding;


### PR DESCRIPTION
Dersom isFullscreen=false brukes samme oppløsning som preview-vinduet for å vise demoen i fullscreen i prod-bygg (man kan enklere se forskjellen ved å trykke enter under kjøring av prod-bygg). Ved å initialisere de til samme verdi får man riktig oppløsning