### PR TITLE
Use BoxGeometry instead of BoxBufferGeometry

### DIFF
--- a/renin/src/ui/AudioBar.ts
+++ b/renin/src/ui/AudioBar.ts
@@ -7,7 +7,6 @@ import {
   RepeatWrapping,
   Texture,
   ShaderMaterial,
-  BoxBufferGeometry,
   sRGBEncoding,
 } from 'three';
 import { colors } from './colors';
@@ -25,7 +24,7 @@ const boxHeight = 40;
 const boxPadding = 8;
 const glowSize = 12;
 
-const boxBufferGeometry = new BoxBufferGeometry();
+const boxBufferGeometry = new BoxGeometry();
 
 const uiboxStore: { [key: string]: UIBox } = {};
 const getUIBox = (name: string) => {

--- a/renin/src/ui/UIBox.ts
+++ b/renin/src/ui/UIBox.ts
@@ -1,5 +1,5 @@
 import {
-  BoxBufferGeometry,
+  BoxGeometry,
   BufferAttribute,
   BufferGeometry,
   Material,
@@ -119,12 +119,12 @@ export function makeRoundedRectangleBufferGeometry(
   return geometry;
 }
 
-const geometry = new BoxBufferGeometry();
+const geometry = new BoxGeometry();
 
 export class UIBox<MaterialType extends Material = MeshBasicMaterial> {
   object3d = new Object3D();
   private mesh: Mesh<BufferGeometry, MaterialType>;
-  private shadow: Mesh<BoxBufferGeometry, RawShaderMaterial>;
+  private shadow: Mesh<BoxGeometry, RawShaderMaterial>;
   options: UIBoxOptions<MaterialType>;
 
   constructor(options: Partial<UIBoxOptions<MaterialType>>) {


### PR DESCRIPTION
<h4>Use BoxGeometry instead of BoxBufferGeometry</h4>


BoxBufferGeometry has been renamed to BoxGeometry in Three.js at some
point.

