### PR TITLE
Add some metadata to npm publishing

### DIFF
--- a/renin/package.json
+++ b/renin/package.json
@@ -6,6 +6,12 @@
   "files": [
     "lib"
   ],
+  "homepage": "https://github.com/ninjadev/renin#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ninjadev/renin.git",
+    "directory": "renin"
+  },
   "scripts": {
     "build": "rm -rf lib && rollup -c && cp -r ../example-project lib/example-project && rm -rf lib/example-project/node_modules"
   },


### PR DESCRIPTION
It would be nice to include readme and license as well, but readme will be copied along automatically if we as part of the release step copy the top-level readme into the published folder (or add a secondary readme inside with release specific information).

And the license is just still missing, so I'll leave that for later.