### PR TITLE
Fix setting playback rate when paused

### DIFF
--- a/renin/src/music.ts
+++ b/renin/src/music.ts
@@ -29,9 +29,9 @@ export class Music {
 
   setPlaybackRate(playbackRate: number) {
     const shouldPlay = !this.paused;
-    this.pause();
     this.playbackRate = playbackRate;
     if (shouldPlay) {
+      this.pause();
       this.play();
     }
   }


### PR DESCRIPTION
We only need to pause and call play again when we're actually currently playing. Calling pause when paused causes a crash (disconnecting the audionode twice).