### PR TITLE
Repair stepOffset in sync.flash

### DIFF
--- a/renin/src/sync.ts
+++ b/renin/src/sync.ts
@@ -14,9 +14,14 @@ export class Sync {
     this.music = music;
   }
 
+  /**
+   * Outputs a number between 0 and 1, signifying the progress between two "flashes", synced to the music.
+   * "stepStride" denotes the number of steps (subdivisions of a beat) between each flash
+   * "stepOffset" offsets the flashes from the start of a beat.
+   */
   flash(frame: number, stepStride: number, stepOffset: number = 0) {
     const step = this.stepForFrame(frame);
-    const startStep = (((step - stepOffset) / stepStride) | 0) * stepStride;
+    const startStep = (((step - stepOffset) / stepStride) | 0) * stepStride + stepOffset;
     const startFrame = this.frameForStep(startStep);
     const endFrame = this.frameForStep(startStep + stepStride);
     return (frame - startFrame) / (endFrame - startFrame);


### PR DESCRIPTION
I couldn't find any traces of us actually having used stepOffset before, so I can't say for sure what the intended purpose was, but this makes it behave more how I was expecting it, letting you offset when in a beat/bar flashes occur.

The trick is that we need the value for startStep to change exactly when we reach the step of its new value. That was out of sync without this fix, giving strange results.