### PR TITLE
Make assets paths relative

### DIFF
--- a/example-project/vite.config.js
+++ b/example-project/vite.config.js
@@ -4,6 +4,7 @@ import reninPlugin from 'renin/lib/ui/vite.mjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 export default defineConfig({
+  base: '',
   plugins: [
     reninPlugin(),
     nodeResolve(),


### PR DESCRIPTION
This is needed in built demos so that they can be ran directly from the file system.