### PR TITLE
Add transitionFromFrame

### DIFF
--- a/renin/src/interpolations.ts
+++ b/renin/src/interpolations.ts
@@ -28,3 +28,14 @@ export function elasticOut(b: number, c: number, d: number, t: number) {
   const tc = ts * t;
   return b + c * (33 * tc * ts + -106 * ts * ts + 126 * tc + -67 * ts + 15 * t);
 }
+
+/**
+ * Transition from 0 to 1 from a specific startFrame for duration duration.
+ * @param frame The current frame
+ * @param duration How many frames the transition takes
+ * @param startFrame  What frame to start the transition at
+ * @returns value in [0, 1) representing the progression into the interval.
+ */
+export function transitionFromFrame(frame: number, duration: number, startFrame: number) {
+  return lerp(0, 1, (frame - startFrame) / duration);
+}


### PR DESCRIPTION
I used this a lot during crank, as i keep forgetting the manual implementation of a transition at a certain frame. I guess i could replace the lerp with a clamp.

The name i used for this function in crank was
'interpolateFrame',

Usage:

```
    const letterGroup1ZPosition = easeIn(
      smoothstep(
        -100,
        0,
        interpolateFrame(frame, fadeDuration, 2489 - fadeDuration)
      ),
      fadeDuration,
      tFadeOut
    );

    const letterGroup2ZPosition = easeIn(
      smoothstep(
        -100,
        0,
        interpolateFrame(frame, fadeDuration, 2524 - fadeDuration)
      ),
      fadeDuration,
      tFadeOut
    );
    const letterGroup3ZPosition = easeIn(
      smoothstep(
        -100,
        0,
        interpolateFrame(frame, fadeDuration, 2560 - fadeDuration)
      ),
      fadeDuration,
      tFadeOut
    );
```