### PR TITLE
Add simple recording feature

### DIFF
--- a/renin/src/style.css
+++ b/renin/src/style.css
@@ -1,3 +1,7 @@
+html, body {
+background: black;
+}
+
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
<h4>Add simple recording feature</h4>


This adds a simple recording feature -- press and hold 'r' to record a
short snippet of the demo for easy sharing in chats/social media. As far
as I can tell, MediaRecorder can only record the entire canvas, so we
need to do a little bit of work to temporarily disable the renin UI when
recording in order to only record the demo itself.

This is separate from the "perfect fps" video export rendering feature,
which is not quick, convenient and real-time in the same was as this is.

