### PR TITLE
Remove accidental double linear -> sRGB conversion

### DIFF
--- a/renin/src/ui/screenShader.glsl
+++ b/renin/src/ui/screenShader.glsl
@@ -4,7 +4,7 @@ uniform sampler2D thirdsOverlay;
 uniform float thirdsOverlayOpacity;
 
 void main() {
-    vec3 color = LinearTosRGB(texture2D(screen, vUv.xy)).rgb;
+    vec3 color = texture2D(screen, vUv.xy).rgb;
     float a = texture2D(thirdsOverlay, vUv.xy).a;
     vec3 inverted = 1. - color;
     color = mix(color, inverted, a * thirdsOverlayOpacity);


### PR DESCRIPTION
<h4>Remove accidental double linear -> sRGB conversion</h4>


This fixes an issue where our demos would accidentally be the wrong
color.

