### PR TITLE
Fix missing canvas texture update on resize in FlatLand in demo project

### DIFF
--- a/example-project/src/FlatLand.ts
+++ b/example-project/src/FlatLand.ts
@@ -17,7 +17,7 @@ export class FlatLand extends ReninNode {
   public resize(width: number, height: number) {
     this.canvas.width = width;
     this.canvas.height = height;
-    console.log(width, height);
+    this.texture = new CanvasTexture(this.canvas);
   }
 
   public render(frame: number, _renderer: WebGLRenderer, renin: Renin) {


### PR DESCRIPTION
This fixes a bug where the canvas would stop animating after pressing enter to see the larger preview